### PR TITLE
Turbo Frames example

### DIFF
--- a/app/views/campaigns/_campaign.html.erb
+++ b/app/views/campaigns/_campaign.html.erb
@@ -1,3 +1,4 @@
+<%= turbo_frame_tag dom_id(campaign, :archive) do %>
 <div id="<%= dom_id campaign %>">
   <p>
     <strong>Name:</strong>
@@ -14,3 +15,4 @@
   </p>
   <br><br><br>
 </div>
+<% end %>


### PR DESCRIPTION
This example wraps the `_campaign` partial in a `turbo_frame_tag`.

Hotwire knows that the request came from inside a `turbo_frame` and will swap out the HTML on the page with the matching `turbo_frame` in the response.

Turbo Frames are useful when you know everything thats changing is contained in the same HTML element.

Everything else works the same as if it was a vanilla rails app with a full-page reload. If you turn off JS it'll fall back to a basic full page reload.

https://github.com/markahesketh/brian-casel-hotwire/assets/1269894/4bb697cb-3873-4dc3-8b9f-9eba9b897965

