### PR TITLE
Turbo stream example

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -59,7 +59,10 @@ class CampaignsController < ApplicationController
 
   def toggle_archived
     @campaign.toggle!(:archived)
-    redirect_to campaigns_url, notice: "Campaign was successfully updated."
+    respond_to do |format|
+      format.html { redirect_to campaigns_url, notice: "Campaign was successfully updated." }
+      format.turbo_stream
+    end
   end
 
   private

--- a/app/views/campaigns/toggle_archived.turbo_stream.erb
+++ b/app/views/campaigns/toggle_archived.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.update @campaign %>

--- a/app/views/campaigns/toggle_archived.turbo_stream.erb
+++ b/app/views/campaigns/toggle_archived.turbo_stream.erb
@@ -1,1 +1,3 @@
 <%= turbo_stream.update @campaign %>
+
+<%#= turbo_stream.update "campaign-counter", Campaign.where(archived: false).count  %>


### PR DESCRIPTION
This example creates a `turbo_stream` response.

Turbo streams are useful if you have multiple areas of the page that need updating within different HTML elements, so a `turbo_frame` doesn't cut it.

For example, you might have a counter at the top of this page to show how many campaigns are unarchived.