### PR TITLE
Morphing example

### DIFF
--- a/app/views/campaigns/index.html.erb
+++ b/app/views/campaigns/index.html.erb
@@ -1,3 +1,5 @@
+<%= turbo_refreshes_with method: :morph, scroll: :preserve %>
+
 <p style="color: green"><%= notice %></p>
 
 <h1>Campaigns</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <%= content_for :head %>
   </head>
 
   <body>


### PR DESCRIPTION
Turbo 8 introduced morphing which means you can do full-page reloads and Turbo will figure out which elements to update.

This can be super powerful where many updates need to be made across a page and multiple `turbo_streams` would become like spaghetti.

In my theoretical example of a counter showing unarchived campaigns, the counter would be updated automatically alongside the campaigns themselves 'for free'.

This takes over the reloading of the whole page, so may not be appropriate for everything, but it can also simplify things massively.